### PR TITLE
fix(forms,data): close dialogs on save, submit-in-flight state, SWR error handling

### DIFF
--- a/src/app/(nest)/error.tsx
+++ b/src/app/(nest)/error.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { WarningCircle, ArrowClockwise, House } from "@phosphor-icons/react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Catches render/runtime errors anywhere under the (nest) route group, so a
+ * crash (e.g. a bad SWR response, see #188) shows a recoverable screen
+ * instead of Next's raw "Application error".
+ */
+export default function NestError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="max-w-md">
+        <CardHeader className="items-center text-center">
+          <WarningCircle className="mb-2 size-10 text-destructive" />
+          <CardTitle>Something went wrong</CardTitle>
+          <CardDescription>
+            {error.message || "An unexpected error occurred while loading this page."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center gap-2">
+          <Button onClick={() => reset()} variant="default">
+            <ArrowClockwise /> Try again
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/home">
+              <House /> Go home
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(nest)/not-found.tsx
+++ b/src/app/(nest)/not-found.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { Compass, House } from "@phosphor-icons/react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+/** Shown for any unmatched route under the (nest) route group. */
+export default function NestNotFound() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="max-w-md">
+        <CardHeader className="items-center text-center">
+          <Compass className="mb-2 size-10 text-muted-foreground" />
+          <CardTitle>Page not found</CardTitle>
+          <CardDescription>
+            There is nothing here. The page may have moved or the link may be wrong.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button asChild variant="default">
+            <Link href="/home">
+              <House /> Go home
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/forms/experiment-form.tsx
+++ b/src/components/forms/experiment-form.tsx
@@ -12,6 +12,7 @@ This form is used to upload new files, and create the required experiment entry 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch } from "react-hook-form"
 import { z } from "zod"
+import { CircleNotch } from "@phosphor-icons/react"
 
 import { ComboFormBox } from "@/components/forms/combo-form-box"
 import { Label } from "@/components/ui/label"
@@ -45,7 +46,7 @@ import { linkFileToEntry, uploadFile } from "@/utils/handlers/fileHandlers"
 import { ParserPreview } from "./ParserPreview"
 import { DataFormatPreview } from "./DataFormatPreview"
 
-export function ExperimentForm({ users, samples, user, experiments, defaultFileList }: { users: any, samples: any, user: any, experiments: any, defaultFileList?: FileList }) {
+export function ExperimentForm({ users, samples, user, experiments, defaultFileList, onSuccess }: { users: any, samples: any, user: any, experiments: any, defaultFileList?: FileList, onSuccess?: () => void }) {
     const [allFileData, setAllFileData] = useState<Array<Partial<ExperimentFormValues>>>([]);
     const [files, setFiles] = useState<FileList | null>(null);
     const [checkSaveFile, setCheckSaveFile] = useState(true);
@@ -105,6 +106,11 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
         const method = 'create';
         const endpointexperiment = `${prepend_path}/api/experiments`;
         let fileId: string | null = null;
+        // Some per-file branches below report a failure via toast without
+        // rejecting their promise, so Promise.all alone can't tell success
+        // from failure. Track it explicitly so the dialog only closes when
+        // every file actually made it.
+        let hadFailure = false;
 
         // Validate experiment type and data compatibility
         if (checkParserSupport(formValues.type)) {
@@ -206,6 +212,7 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
                     } catch (error) {
                         console.error("Error uploading file:", error);
                         toast.error("Failed to upload file");
+                        hadFailure = true;
                         return;
                     }
                 }
@@ -272,6 +279,7 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
                             toast.error("Error!", {
                                 description: errorData.error || "Error submitting the form.",
                             });
+                            hadFailure = true;
                         } else {
                             const result = await experimentResponse.json();
                             // If we have a file, link it to the newly created experiment
@@ -284,6 +292,7 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
                     catch (error) {
                         console.error("Error uploading file:", error);
                         toast.error("Failed to upload file");
+                        hadFailure = true;
                     }
                 } else if (fileValues.dataFields && fileValues.dataFields.experimentData) {
                     // Handle structured experiment data with embedded traits
@@ -339,7 +348,10 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
             mutate(`${prepend_path}/api/experiments`);
             mutate(`${prepend_path}/api/traits`);
 
-            setAllFileData([]);
+            if (!hadFailure) {
+                setAllFileData([]);
+                onSuccess?.();
+            }
 
         } catch (error) {
             console.error("Error submitting the form", error);
@@ -716,8 +728,9 @@ export function ExperimentForm({ users, samples, user, experiments, defaultFileL
           </Tabs>
           <Button
             type="submit"
-            disabled={allFileData.length === 0}
+            disabled={allFileData.length === 0 || form.formState.isSubmitting}
           >
+            {form.formState.isSubmitting && <CircleNotch className="animate-spin" />}
             Submit
           </Button>
         </form>

--- a/src/components/forms/sample-form.tsx
+++ b/src/components/forms/sample-form.tsx
@@ -7,7 +7,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import { Calendar } from "@/components/ui/calendar";
-import { CalendarDots } from "@phosphor-icons/react";
+import { CalendarDots, CircleNotch } from "@phosphor-icons/react";
 import { format } from "date-fns";
 
 import { ComboFormBox } from "@/components/forms/combo-form-box";
@@ -77,12 +77,14 @@ export function SampleForm({
   id,
   user,
   page,
+  onSuccess,
 }: {
   users: any;
   samples: any;
   id?: string | number;
   user: any;
   page?: string;
+  onSuccess?: () => void;
 }) {
   const { sampletypes, samplesubtypes } = useConfigTypes();
   const { idGeneration, labInfo, loading: settingsLoading } = useMainSettings();
@@ -271,7 +273,10 @@ export function SampleForm({
     notes?: string;
   };
 
-  async function onSubmit(values: z.infer<typeof formSchema>) {
+  // keepOpen distinguishes the two submit buttons: "Submit" closes the dialog
+  // via onSuccess, "Save and add another" clears the form for the next entry
+  // and leaves the dialog open.
+  async function onSubmit(values: z.infer<typeof formSchema>, keepOpen = false) {
     const method = "create";
     const endpoint = `${prepend_path}/api/samples`;
 
@@ -320,6 +325,24 @@ export function SampleForm({
       toast.success("Sample saved");
 
       mutate(`${prepend_path}/api/samples`);
+
+      if (keepOpen) {
+        // Keep type, parent and responsible: entering a run of samples of the
+        // same kind is the point of this button.
+        form.reset({
+          nomenclature: "",
+          name: "",
+          type: values.type,
+          parentId: values.parentId,
+          responsible: values.responsible,
+          sex: "unknown",
+          date: values.date,
+          includeSubsampleShortened: true,
+          custom: {},
+        });
+      } else {
+        onSuccess?.();
+      }
     } catch (error) {
       console.error("Error submitting the form", error);
       toast.error("Error!", {
@@ -887,7 +910,7 @@ export function SampleForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={form.handleSubmit((values) => onSubmit(values))} className="space-y-4">
         <ComboFormBox
           control={form.control}
           setValue={form.setValue}
@@ -934,9 +957,21 @@ export function SampleForm({
           )}
         />
 
-        <Button key="submit" type="submit">
-          Submit
-        </Button>
+        <div className="flex gap-2">
+          <Button key="submit" type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting && <CircleNotch className="animate-spin" />}
+            Submit
+          </Button>
+          <Button
+            key="submit-and-add-another"
+            type="button"
+            variant="outline"
+            disabled={form.formState.isSubmitting}
+            onClick={form.handleSubmit((values) => onSubmit(values, true))}
+          >
+            Save and add another
+          </Button>
+        </div>
       </form>
     </Form>
   );

--- a/src/components/forms/smart-vaul.tsx
+++ b/src/components/forms/smart-vaul.tsx
@@ -84,6 +84,12 @@ export function SmartVaul({
       </Button>
     );
 
+  // Closes the dialog once a form's submit actually succeeds, so a saved
+  // record doesn't sit there re-editable/re-submittable. Sample creation
+  // instead gets its own "Save and add another" button that resets in place
+  // for entering several samples in a row without this firing.
+  const handleSuccess = React.useCallback(() => setOpen(false), []);
+
   const body =
     status !== "authenticated" ? (
       <div className="space-y-3 p-4">
@@ -92,18 +98,19 @@ export function SmartVaul({
         <Skeleton className="h-9 w-full" />
       </div>
     ) : formType === "traits" ? (
-      <TraitForm users={users} samples={samples} user={user} />
+      <TraitForm users={users} samples={samples} user={user} onSuccess={handleSuccess} />
     ) : formType === "samples" ? (
-      <SampleForm users={users} samples={samples} id={id} user={user} page={page} />
+      <SampleForm users={users} samples={samples} id={id} user={user} page={page} onSuccess={handleSuccess} />
     ) : formType === "experiments" ? (
       <ExperimentForm
         users={users}
         samples={samples}
         user={user}
         experiments={experiments}
+        onSuccess={handleSuccess}
       />
     ) : (
-      <UserForm />
+      <UserForm onSuccess={handleSuccess} />
     );
 
   if (isMobile) {

--- a/src/components/forms/trait-form.tsx
+++ b/src/components/forms/trait-form.tsx
@@ -6,7 +6,7 @@ import { useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { Calendar } from "@/components/ui/calendar"
-import { CalendarDots } from "@phosphor-icons/react"
+import { CalendarDots, CircleNotch } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { mutate } from "swr"
 
@@ -53,7 +53,7 @@ const formSchema = z.object({
 
 
 
-export function TraitForm({ users, samples, user }: { users: any, samples: any, user: any }) {
+export function TraitForm({ users, samples, user, onSuccess }: { users: any, samples: any, user: any, onSuccess?: () => void }) {
     const [files, setFiles] = useState<FileList | null>(null);
     const [selectedTypeFeatures, setSelectedTypeFeatures] = useState<LabelType>();
     const { traittypes, equipmenttypes } = useConfigTypes();
@@ -176,6 +176,7 @@ export function TraitForm({ users, samples, user }: { users: any, samples: any, 
                         await linkFileToEntry(fileId, 'trait', response.id);
                 });
             }
+            onSuccess?.();
         }
     }
 
@@ -308,7 +309,10 @@ export function TraitForm({ users, samples, user }: { users: any, samples: any, 
                         />
                     </TabsContent>
                 </Tabs>
-                <Button type="submit">Submit</Button>
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                    {form.formState.isSubmitting && <CircleNotch className="animate-spin" />}
+                    Submit
+                </Button>
             </form>
         </Form >
     )

--- a/src/components/forms/user-form.tsx
+++ b/src/components/forms/user-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
-
+import { CircleNotch } from "@phosphor-icons/react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -35,7 +35,7 @@ const formSchema = z.object({
     databases: z.array(z.string()).min(1, { message: "At least one database must be selected" }),
 })
 
-export function UserForm({}) {
+export function UserForm({ onSuccess }: { onSuccess?: () => void } = {}) {
     const { isAdmin } = useCurrentUser();
     const { databases, isDatabasesLoading, databasesError } = useDatabases();
     
@@ -86,6 +86,7 @@ export function UserForm({}) {
                     description: `Created user: ${values.name} with role: ${values.role}`,
                 });
                 form.reset(); // Reset form after successful submission
+                onSuccess?.();
             } else {
                 toast.error("Failed to create user", {
                     description: result.error || "An unknown error occurred",
@@ -220,7 +221,10 @@ export function UserForm({}) {
                     )}
                 />
 
-                <Button type="submit">Submit</Button>
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                    {form.formState.isSubmitting && <CircleNotch className="animate-spin" />}
+                    Submit
+                </Button>
             </form>
         </Form>
     )

--- a/src/hooks/useExperimentData.js
+++ b/src/hooks/useExperimentData.js
@@ -1,6 +1,7 @@
+// Uses the global SWRConfig fetcher (src/app/providers/swr-provider.tsx), which
+// throws on a non-OK response so `experimentsError`/`experimentError` actually
+// reflect a failed request instead of resolving with the error body as data.
 import useSWR from 'swr';
-
-const fetcher = url => fetch(url).then(res => res.json());
 
 export const useExperimentsData = (
     prependPath, 
@@ -17,7 +18,7 @@ export const useExperimentsData = (
     
     const url = `${prependPath}/api/experiments${params.toString() ? '?' + params.toString() : ''}`;
     
-    const { data, error, isValidating } = useSWR(url, fetcher, options);
+    const { data, error, isValidating } = useSWR(url, options);
     
     return {
         experimentsData: data,
@@ -44,7 +45,7 @@ export const useExperimentData = (
         type ? `type=${type}` : ''
     }`;
     
-    const { data, error, isValidating } = useSWR(url, fetcher, options);
+    const { data, error, isValidating } = useSWR(url, options);
     
     return {
         experimentData: data,

--- a/src/hooks/useFilesData.js
+++ b/src/hooks/useFilesData.js
@@ -1,9 +1,11 @@
-// useUserData.js
+// useFilesData.js
+// Uses the global SWRConfig fetcher (src/app/providers/swr-provider.tsx), which
+// throws on a non-OK response so `filesError` actually reflects a failed
+// request instead of resolving with the error body as if it were data.
 import useSWR from 'swr';
-const fetcher = url => fetch(url).then(res => res.json());
 
 export const useFilesData = (prependPath) => {
-    const { data, error } = useSWR(`${prependPath}/api/files`, fetcher);
+    const { data, error } = useSWR(`${prependPath}/api/files`);
     return {
         filesData: data,
         filesError: error,

--- a/src/hooks/useSampleData.js
+++ b/src/hooks/useSampleData.js
@@ -1,16 +1,16 @@
 // useSampleData.js
+// Uses the global SWRConfig fetcher (src/app/providers/swr-provider.tsx), which
+// throws on a non-OK response so `samplesError` actually reflects a failed
+// request instead of resolving with the error body as if it were data.
 import useSWR, { SWRConfiguration } from 'swr';
 
-const fetcher = url => fetch(url).then(res => res.json());
-
 export const useSampleData = (prependPath, options) => {
-    const { 
-        data, 
-        error, 
+    const {
+        data,
+        error,
         isValidating // Adding this since we used it in the page
     } = useSWR(
-        `${prependPath}/api/samples`, 
-        fetcher,
+        `${prependPath}/api/samples`,
         options // Pass through any SWR options
     );
 

--- a/src/hooks/useTraitData.js
+++ b/src/hooks/useTraitData.js
@@ -1,7 +1,8 @@
 // useTraitData.js
-// 
+// Uses the global SWRConfig fetcher (src/app/providers/swr-provider.tsx), which
+// throws on a non-OK response so `traitsError` actually reflects a failed
+// request instead of resolving with the error body as if it were data.
 import useSWR from 'swr';
-const fetcher = url => fetch(url).then(res => res.json());
 
 export const useTraitData = (
     prependPath, 
@@ -19,7 +20,7 @@ export const useTraitData = (
         type ? `type=${type}` : ''
     }`;
 
-    const { data, error, isValidating } = useSWR(url, fetcher, options);
+    const { data, error, isValidating } = useSWR(url, options);
     
     return {
         traitsData: data,

--- a/src/hooks/useUserData.js
+++ b/src/hooks/useUserData.js
@@ -1,10 +1,12 @@
 // useUserData.js
+// Uses the global SWRConfig fetcher (src/app/providers/swr-provider.tsx), which
+// throws on a non-OK response so `usersError` actually reflects a failed
+// request instead of resolving with the error body as if it were data.
 import useSWR from 'swr';
-const fetcher = url => fetch(url).then(res => res.json());
 
 export const useUserData = (prependPath, options, isAuth = false) => {
     const path = isAuth ? `${prependPath}/api/users?auth=true` : `${prependPath}/api/users`;
-    const { data, error } = useSWR(path, fetcher, options);
+    const { data, error } = useSWR(path, options);
     return {
         usersData: data,
         usersError: error,


### PR DESCRIPTION
## What
### Dialog close / reset on save
- SmartVaul passes `onSuccess` into each entity form, which closes the dialog once the save actually succeeds
- Sample form gets a second button, "Save and add another", which resets the form (keeping type, parent and responsible) instead of closing, for entering a run of samples

### Submit-in-flight state
- Sample, trait, user and experiment forms disable Submit and show a spinner (`CircleNotch`, matching `photo-upload.tsx`) while the request is in flight
- Experiment form: added an explicit `hadFailure` flag, since some of its per-file branches report failure via toast without rejecting their promise — `onSuccess` and the file-list reset now only fire when every file actually made it

### SWR error handling
- `useSampleData`, `useUserData`, `useTraitData`, `useExperimentData`, `useFilesData` no longer define a local fetcher that swallows non-OK responses; they use the global SWRConfig fetcher, which throws on a bad response so the `*Error` return value actually reflects a failed request

### Error/not-found boundaries
- Added `src/app/(nest)/error.tsx` (retry + link home) and `src/app/(nest)/not-found.tsx`

## Why
Reviewed the frontend for UX issues; these four were the highest-impact.

## Behaviour changes
- Creating a sample/trait/user/experiment now closes its dialog on success instead of leaving it open and populated
- A slow or double-clicked submit no longer risks a duplicate record
- A session-expiry or server error on the sample/user/trait/experiment/files list now shows the page's existing error state instead of crashing on non-array data
- An uncaught error or unmatched route under the nest app shows a recoverable screen instead of Next's raw error page

## Checks
- `next build`: pass
- `tsc --noEmit`: pass
- `npx eslint` on changed files: pass
- Tests: full suite (379 tests) pass

## Merge
### Base
`develop`

### Closes
#186, #187, #188, #189