### PR TITLE
fix(tables,nav,forms): persist table state, dedupe config fetches, fix delete/UX gaps

### DIFF
--- a/src/app/(nest)/sample/[id]/page.js
+++ b/src/app/(nest)/sample/[id]/page.js
@@ -84,6 +84,19 @@ export default function IdPage() {
     await handleStatusChangeSample(sampleId, "parentId", newParentId, true);
   }
 
+  // Shared by the desktop and mobile Delete buttons below, so the two
+  // copies of the confirm dialog can't drift in behaviour.
+  const handleDeleteAndBack = async () => {
+    try {
+      await handleDeleteSample(sample._id);
+      /* go back to previous page */
+      window.history.back();
+    } catch {
+      // handleDeleteSample already showed an error toast; stay on the page
+      // instead of navigating away from a sample that is still there.
+    }
+  };
+
   const handleSearch = (e) => {
     if (e.key === 'Enter') {
       const foundSample = samplesData.find(sample => sample.name.toLowerCase().includes(searchInput.toLowerCase()) || sample._id.includes(searchInput));
@@ -229,12 +242,7 @@ export default function IdPage() {
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                       <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction onClick={() => {
-                        handleDeleteSample(sample._id)
-                        /* go back to previous page */
-                        window.history.back()
-                      }
-                      }>Continue</AlertDialogAction>
+                      <AlertDialogAction onClick={handleDeleteAndBack}>Continue</AlertDialogAction>
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
@@ -306,12 +314,7 @@ export default function IdPage() {
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => {
-                      handleDeleteSample(sample._id)
-                      /* go back to previous page */
-                      window.history.back()
-                    }
-                    }>Continue</AlertDialogAction>
+                    <AlertDialogAction onClick={handleDeleteAndBack}>Continue</AlertDialogAction>
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>

--- a/src/app/(nest)/sample/[id]/s_trait/page.js
+++ b/src/app/(nest)/sample/[id]/s_trait/page.js
@@ -742,7 +742,7 @@ export default function IDTraitPage() {
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => handleDeleteTrait(trait._id)}>Continue</AlertDialogAction>
+                  <AlertDialogAction onClick={() => handleDeleteTrait(trait._id).catch(() => {})}>Continue</AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
@@ -800,7 +800,7 @@ export default function IDTraitPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <DataTable columns={traitColumns} data={filteredTraits} onStatusChange={handleStatusChangeTrait}
+            <DataTable columns={traitColumns} data={filteredTraits} onStatusChange={handleStatusChangeTrait} tableId="own"
             ></DataTable>
           </CardContent>
         </Card >
@@ -811,7 +811,7 @@ export default function IDTraitPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <DataTable columns={traitColumns} data={childrenTraits} onStatusChange={handleStatusChangeTrait}
+            <DataTable columns={traitColumns} data={childrenTraits} onStatusChange={handleStatusChangeTrait} tableId="children"
             ></DataTable>
           </CardContent>
         </Card >

--- a/src/app/(nest)/samples/maintenance/page.tsx
+++ b/src/app/(nest)/samples/maintenance/page.tsx
@@ -132,6 +132,7 @@ export default function MaintenancePage() {
                     <AccordionContent>
                         <DataTable
                             {...sampleHandlers}
+                            tableId="alive"
                             columns={aliveColumns}
                             data={alive}
                             renderToolbar={(table: TanstackTable<any>) => (
@@ -145,6 +146,7 @@ export default function MaintenancePage() {
                     <AccordionContent>
                         <DataTable
                             {...sampleHandlers}
+                            tableId="preserved"
                             columns={deadColumns}
                             data={dead}
                             renderToolbar={(table: TanstackTable<any>) => (
@@ -158,6 +160,7 @@ export default function MaintenancePage() {
                     <AccordionContent>
                         <DataTable
                             {...sampleHandlers}
+                            tableId="position"
                             columns={positionColumns}
                             data={position}
                             renderToolbar={(table: TanstackTable<any>) => (

--- a/src/app/(nest)/traits/columns.js
+++ b/src/app/(nest)/traits/columns.js
@@ -26,6 +26,7 @@ export const baseColumns = [
   {
     accessorKey: "std",
     header: "Standard Deviation",
+    meta: { label: "Standard Deviation" },
     // show only 4 decimal places
     cell: (info) => {
       const trait = info.row.original;
@@ -39,6 +40,7 @@ export const baseColumns = [
   {
     accessorKey: "listvals",
     header: "List of Values",
+    meta: { label: "List of Values" },
     // show only first 5 values
     cell: (info) => {
       const trait = info.row.original;
@@ -51,6 +53,7 @@ export const baseColumns = [
   {
     accessorKey: "trait_download",
     header: "Download JSON",
+    meta: { label: "Download JSON" },
     cell: (info) => {
       const trait = info.row.original;
       return (

--- a/src/components/forms/sample-form.tsx
+++ b/src/components/forms/sample-form.tsx
@@ -71,6 +71,14 @@ const sexOptions = [
   { value: "unknown", label: "Unknown" },
 ];
 
+// Nominatim's reverse-geocode address, reduced to a readable "road,
+// neighbourhood, city, county, country" line for the location field and toast.
+function formatAddress(address: Record<string, unknown> | undefined): string {
+  if (!address) return "";
+  const { road, neighbourhood, city, county, country } = address as Record<string, string | undefined>;
+  return [road, neighbourhood, city, county, country].filter(Boolean).join(", ");
+}
+
 export function SampleForm({
   users,
   samples,
@@ -119,24 +127,7 @@ export function SampleForm({
                       lon,
                     });
 
-                    // Destructuring the location object to extract necessary fields
-                    const { road, neighbourhood, city, county, country } =
-                      geodata.location;
-
-                    // Constructing the address string with safe checks
-                    const addressParts = [
-                      road,
-                      neighbourhood,
-                      city,
-                      county,
-                      country,
-                    ].filter((part) => part !== undefined); // Filters out undefined parts to avoid "undefined" in the string
-
-                    // Join the parts with a comma and space
-                    const address = addressParts.join(", ");
-
-                    // Setting the value in the form
-                    form.setValue("location", address);
+                    form.setValue("location", formatAddress(geodata.location));
                   } catch (error) {
                     console.error("Failed to fetch location data:", error);
                     toast.error("Failed to fetch location data");
@@ -176,7 +167,7 @@ export function SampleForm({
         form.setValue("lon", lon);
         fetchNameLocationFromCoordinates({ lat, lon })
           .then((geodata) => {
-            form.setValue("location", geodata.location);
+            form.setValue("location", formatAddress(geodata.location));
           })
           .catch((error) => {
             console.error("Failed to fetch location data:", error);
@@ -370,7 +361,9 @@ export function SampleForm({
 
     if (response.ok) {
       const geodata = await response.json();
-      toast.message(JSON.stringify(geodata.coordinates));
+      const found = geodata.coordinates?.display_name
+        ?? `${geodata.coordinates?.lat}, ${geodata.coordinates?.lon}`;
+      toast.message(`Location found: ${found}`);
       if (geodata.attribution) {
         toast.info(geodata.attribution);
       }
@@ -418,8 +411,7 @@ export function SampleForm({
 
       if (response.ok) {
         const geodata = await response.json();
-        // Displaying information as a message; adjust based on your UI framework's capabilities
-        toast.message(JSON.stringify(geodata));
+        toast.message(`Location found: ${formatAddress(geodata.location) || "unknown"}`);
         if (geodata.attribution) {
           toast.info(geodata.attribution);
         }

--- a/src/components/nest/navbar.tsx
+++ b/src/components/nest/navbar.tsx
@@ -167,6 +167,10 @@ export function NavBar() {
   const router = useRouter();
   const [userDatabases, setUserDatabases] = useState<string[]>([]);
   const [activeDatabase, setActiveDatabase] = useState<string>("");
+  // Switching database now navigates with router.push instead of a full page
+  // reload (see handleDatabaseChange), so the mobile sheet no longer gets
+  // torn down for free by the reload — close it explicitly instead.
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // Owned here (not inside DeveloperNewsCard) so the bell's badge and the
   // popover's list agree on the same fetch and the same dismissals.
@@ -237,9 +241,13 @@ export function NavBar() {
       toast.success("Database changed successfully");
 
       // Every cached SWR response (samples, users, traits...) belongs to the
-      // database we just left. Drop it all so mounted pages refetch under
-      // the new one instead of showing the previous database's data.
-      await mutate(() => true, undefined, { revalidate: true });
+      // database we just left. Revalidate it all in the background — not
+      // awaited, so this doesn't stall the navigation below on every
+      // in-flight request across the app — so mounted components (this
+      // navbar included, since it doesn't unmount on navigation) pick up
+      // the new database instead of keeping the previous one's data.
+      mutate(() => true, undefined, { revalidate: true });
+      setMobileMenuOpen(false);
       router.push("/home");
     } catch (error) {
       console.error("Error changing database:", error);
@@ -324,7 +332,7 @@ export function NavBar() {
       {/* -------------------------------------------------------------------------------------- */}
       {/*                                  Mobiles and Vertical                                  */}
       {/* -------------------------------------------------------------------------------------- */}
-      <Sheet>
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
         <SheetTrigger asChild>
           <Button variant="outline" size="icon" className="shrink-0 md:hidden">
             <List className="h-5 w-5" />

--- a/src/components/nest/navbar.tsx
+++ b/src/components/nest/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { mutate } from "swr";
 import {
   BugBeetle,
   Bell,
@@ -235,8 +236,11 @@ export function NavBar() {
       setActiveDatabase(data.activeDatabase);
       toast.success("Database changed successfully");
 
-      // Redirect to home page and refresh
-      window.location.href = "/home";
+      // Every cached SWR response (samples, users, traits...) belongs to the
+      // database we just left. Drop it all so mounted pages refetch under
+      // the new one instead of showing the previous database's data.
+      await mutate(() => true, undefined, { revalidate: true });
+      router.push("/home");
     } catch (error) {
       console.error("Error changing database:", error);
       toast.error("Failed to change database");
@@ -349,47 +353,39 @@ export function NavBar() {
                 ))}
               </SelectContent>
             </Select>
+            {/* Same sections as the desktop menu (samplesProps included, so a
+                lab's custom sample types and Settings show up here too),
+                just laid out as a flat list instead of dropdowns. */}
+            {[usersProps, samplesProps, experimentsProps, traitsProps, settingsProps].map((section) => (
+              <div key={section.label} className="grid gap-2">
+                <Link
+                  href={section.href}
+                  className="text-foreground hover:text-primary"
+                >
+                  {section.label}
+                </Link>
+                {section.options.length > 0 && (
+                  <div className="grid gap-2 pl-3 text-base">
+                    {section.options.map((option) => (
+                      <Link
+                        key={option.href}
+                        href={prepend_path + option.href}
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        {option.title}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
             <Link
-              href="/users"
+              href="https://daniele-liprandi.github.io/EvoNEST-backbone/"
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground"
             >
-              Users
-            </Link>
-            <Link
-              href="/samples"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              Samples
-            </Link>
-            <Link
-              href="/samples/maintenance"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              Maintenance
-            </Link>
-            <Link
-              href="/experiments"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              Experiments
-            </Link>
-            <Link
-              href="/traits"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              Traits
-            </Link>
-            <Link
-              href="/traits/analysis"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              Trait analysis
-            </Link>
-            <Link
-              href="/samples/qrlabels"
-              className="text-muted-foreground hover:text-foreground"
-            >
-              QR labels
+              Documentation
             </Link>
             <Link
               href="/api-docs"

--- a/src/components/tables/columns.js
+++ b/src/components/tables/columns.js
@@ -63,16 +63,17 @@ import { handleFileDownloads } from "@/utils/handlers/experimentHandlers";
         
         onStatusChange(dataRow._id, key, processedValue); // Send the correctly typed value
       };
-      
+
       return (
-        <Input 
-          className='flex min-w-24 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none' 
-          value={inputValue} 
+        <Input
+          className='flex min-w-24 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
+          value={inputValue}
           onChange={handleChange}
           type={typeof dataRow[key] === 'number' ? 'number' : 'text'} // Use number input for numbers
         />
       );
-    }
+    },
+    meta: { label },
   }
 );
 
@@ -128,6 +129,7 @@ export const sortableFilterableColumn = (key, label, filterFn = "includesString"
       </div>
     ),
     filterFn: filterFn,
+    meta: { label },
   }
 );
 
@@ -147,7 +149,8 @@ export const sortableFilterableNumericColumn = (key, label) => ({
     else
       return row[key];
   },
-  filterFn: "inNumberRange"
+  filterFn: "inNumberRange",
+  meta: { label },
 });
 
 
@@ -189,6 +192,22 @@ export const rowActionsColumn = ({ entityLabel, editFields = [], titleField = "n
     const row = info.row.original;
     const { onDelete, onUpdateFields } = info.table.options.meta;
     const label = row?.[titleField] || `this ${entityLabel}`;
+    const [deleting, setDeleting] = useState(false);
+
+    // The AlertDialog closes as soon as Action is clicked (Radix's own
+    // behaviour), so the pending state shows on the trash button itself,
+    // which stays visible until the row disappears on revalidation.
+    async function confirmDelete() {
+      setDeleting(true);
+      try {
+        await onDelete(row._id);
+      } catch {
+        // onDelete already reported the failure via toast.
+      } finally {
+        setDeleting(false);
+      }
+    }
+
     return (
       <div className="flex items-center gap-1">
         {editFields.length > 0 && onUpdateFields ? (
@@ -203,8 +222,8 @@ export const rowActionsColumn = ({ entityLabel, editFields = [], titleField = "n
         {onDelete ? (
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label={`Delete ${entityLabel}`}>
-                <Trash className="size-4" />
+              <Button variant="ghost" size="icon" aria-label={`Delete ${entityLabel}`} disabled={deleting}>
+                {deleting ? <ArrowClockwise className="size-4 animate-spin" /> : <Trash className="size-4" />}
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
@@ -214,7 +233,7 @@ export const rowActionsColumn = ({ entityLabel, editFields = [], titleField = "n
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={() => onDelete(row._id)}>Delete</AlertDialogAction>
+                <AlertDialogAction onClick={confirmDelete}>Delete</AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
@@ -259,6 +278,7 @@ export const responsibleColumn = () => (
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Responsible" />
     ),
+    meta: { label: "Responsible" },
   }
 );
 
@@ -282,7 +302,8 @@ export const sampleColumn = (fieldId, fieldname, label, to_traits = false) => {
           <Link href={url} target="_blank">{sampleName}</Link>
         </div>
       );
-    }
+    },
+    meta: { label },
   };
 };
 
@@ -299,6 +320,7 @@ export const recentChangeDateColumn = () => (
       const date = new Date(info.row.original.recentChangeDate);
       return date.toLocaleDateString("en-UK", { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric' });
     },
+    meta: { label: "Last Change" },
   }
 );
 
@@ -494,6 +516,7 @@ export const toggleFieldColumn = (key, header, options, { filter = false } = {})
       />
     );
   },
+  meta: { label: header },
 });
 
 export const lifestageColumn = () => toggleFieldColumn("lifestage", "Life Stage", LIFESTAGE_OPTIONS);
@@ -533,6 +556,7 @@ const incrementButtonColumn = (field, header, Icon, tooltip) => ({
       </TooltipProvider>
     );
   },
+  meta: { label: header },
 });
 
 export const fedButtonColumn = () => incrementButtonColumn("fed", "Feed", Carrot, "Record a feeding");
@@ -540,6 +564,7 @@ export const hungryProgressbarColumn = () => (
   {
     accessorKey: "lastFed",
     header: "Belly",
+    meta: { label: "Belly" },
     cell: function Cell(info) {
       const sample = info.row.original;
 
@@ -613,6 +638,7 @@ export function customColumn(def) {
           </Button>
         );
       },
+      meta: { label },
     };
   }
 
@@ -625,6 +651,7 @@ export function customColumn(def) {
       accessorKey: def.field || key,
       header: label,
       cell: (info) => <ProgressFromDate value={info.row.original[def.field || key]} days={def.days} />,
+      meta: { label },
     };
   }
 
@@ -638,6 +665,7 @@ export function customColumn(def) {
       </div>
     ),
     cell: (info) => formatCell(kind, info.getValue()),
+    meta: { label },
   };
 }
 
@@ -755,7 +783,8 @@ export const silktypeColumn = () => ({
     return (
       <SilkTypeBadge silktype={sample.silktype}></SilkTypeBadge>
     );
-  }
+  },
+  meta: { label: "Type of silk" },
 });
 
 

--- a/src/components/tables/data-table-toolbar.jsx
+++ b/src/components/tables/data-table-toolbar.jsx
@@ -20,13 +20,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-// "recentChangeDate" -> "Recent change date". Column ids are the data keys;
-// most headers are JSX so there is no plain-text label to reuse.
+// "recentChangeDate" -> "Recent change date". Fallback for a column whose def
+// carries no meta.label (most headers are JSX so there is no plain-text label
+// to reuse otherwise) — see columnLabel below.
 function humanise(id) {
   return id
     .replace(/([a-z])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ")
     .replace(/^./, (c) => c.toUpperCase());
+}
+
+// Prefer the column def's own label (set on custom/config-driven fields and
+// the built-ins whose title doesn't match their humanised accessor key) over
+// guessing one from the raw data key.
+function columnLabel(column) {
+  return column.columnDef.meta?.label ?? humanise(column.id);
 }
 
 function saveBlob(blob, filename) {
@@ -113,7 +121,7 @@ export function DataTableToolbar({ table, entity, onExportRelated = null, childr
                     onCheckedChange={(value) => column.toggleVisibility(!!value)}
                     onSelect={(event) => event.preventDefault()}
                   >
-                    {humanise(column.id)}
+                    {columnLabel(column)}
                   </DropdownMenuCheckboxItem>
                 ))}
             </DropdownMenuContent>

--- a/src/components/tables/data-table.js
+++ b/src/components/tables/data-table.js
@@ -89,6 +89,7 @@ const fuzzyFilter = (row, columnId, value, addMeta) => {
  *   bulkEntityLabel?: string,
  *   renderToolbar?: ((table: any) => any) | null,
  *   renderBulkActions?: ((table: any) => any) | null,
+ *   tableId?: string,
  * }} props
  */
 export function DataTable({
@@ -106,12 +107,18 @@ export function DataTable({
   bulkEntityLabel = "row",
   renderToolbar = null,
   renderBulkActions = null,
+  // Distinguishes multiple DataTables on the same route (e.g. the tables on
+  // /samples/maintenance, or "own"/"children" on a sample's trait page) so
+  // they don't share one storage key. Pages with a single table can leave
+  // this out.
+  tableId = "",
 }) {
   const pathname = usePathname();
+  const storageKey = tableId ? `${pathname}::${tableId}` : pathname;
   // Read once per mount, not on every render.
   const storedRef = useRef(null);
   if (storedRef.current === null) {
-    storedRef.current = readStoredTableState(pathname) ?? {};
+    storedRef.current = readStoredTableState(storageKey) ?? {};
   }
   const stored = storedRef.current;
 
@@ -128,12 +135,12 @@ export function DataTable({
   // coming back to this table (or reopening a sample and returning) doesn't
   // reset them to the defaults.
   useEffect(() => {
-    writeStoredTableState(pathname, {
+    writeStoredTableState(storageKey, {
       sorting,
       columnVisibility,
       pageSize: pagination.pageSize,
     });
-  }, [pathname, sorting, columnVisibility, pagination.pageSize]);
+  }, [storageKey, sorting, columnVisibility, pagination.pageSize]);
 
   const table = useReactTable({
     data,

--- a/src/components/tables/data-table.js
+++ b/src/components/tables/data-table.js
@@ -30,10 +30,37 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import { CaretLeft, CaretRight, CaretDoubleLeft, CaretDoubleRight } from "@phosphor-icons/react";
 
 import { BulkActionsBar } from "@/components/tables/bulk-actions-bar";
+
+// Sorting, column visibility and page size are per-table preferences, kept
+// under the page's own pathname so different sample-type tables don't share
+// a setting. Page index is deliberately not persisted here: starting back at
+// page 0 is safer than reopening on a page that may no longer exist.
+const STORAGE_PREFIX = "evonest.table.";
+
+function readStoredTableState(key) {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTableState(key, state) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(state));
+  } catch {
+    // Storage may be unavailable (private mode, quota) — the preference just
+    // doesn't persist this time.
+  }
+}
 
 const fuzzyFilter = (row, columnId, value, addMeta) => {
   const itemRank = rankItem(row.getValue(columnId), value);
@@ -80,14 +107,33 @@ export function DataTable({
   renderToolbar = null,
   renderBulkActions = null,
 }) {
+  const pathname = usePathname();
+  // Read once per mount, not on every render.
+  const storedRef = useRef(null);
+  if (storedRef.current === null) {
+    storedRef.current = readStoredTableState(pathname) ?? {};
+  }
+  const stored = storedRef.current;
+
   const [columnFilters, setColumnFilters] = useState([]);
-  const [sorting, setSorting] = useState([]);
+  const [sorting, setSorting] = useState(() => stored.sorting ?? []);
   const [rowSelection, setRowSelection] = useState({});
-  const [columnVisibility, setColumnVisibility] = useState({});
+  const [columnVisibility, setColumnVisibility] = useState(() => stored.columnVisibility ?? {});
   const [pagination, setPagination] = useState({
-    pageIndex: 0, //initial page index
-    pageSize: 10, //default page size
+    pageIndex: 0, //initial page index — not persisted, see readStoredTableState above
+    pageSize: stored.pageSize ?? 10,
   });
+
+  // Persist sorting/column visibility/page size per page, so leaving and
+  // coming back to this table (or reopening a sample and returning) doesn't
+  // reset them to the defaults.
+  useEffect(() => {
+    writeStoredTableState(pathname, {
+      sorting,
+      columnVisibility,
+      pageSize: pagination.pageSize,
+    });
+  }, [pathname, sorting, columnVisibility, pagination.pageSize]);
 
   const table = useReactTable({
     data,
@@ -124,6 +170,17 @@ export function DataTable({
       pagination,
     },
   });
+
+  // autoResetPageIndex is off above so sorting/revalidation don't bounce the
+  // user back to page 1, but that means a filter that shrinks the result set
+  // can leave the current page past the end ("No results." with rows sitting
+  // on an earlier page). Snap back only in that case.
+  useEffect(() => {
+    const total = table.getFilteredRowModel().rows.length;
+    if (total > 0 && pagination.pageIndex > 0 && pagination.pageIndex * pagination.pageSize >= total) {
+      table.setPageIndex(0);
+    }
+  }, [data, columnFilters, pagination.pageIndex, pagination.pageSize]);
 
   return (
     <div className="flex flex-col gap-3">

--- a/src/hooks/useConfigTypes.ts
+++ b/src/hooks/useConfigTypes.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { 
+import useSWR from 'swr'
+import {
   sampletypes as defaultSampleTypes,
   traittypes as defaultTraitTypes,
   equipmenttypes as defaultEquipmentTypes,
@@ -21,79 +21,58 @@ interface UseConfigTypesResult {
   refresh: () => void
 }
 
+// Every consumer (navbar, sample pages, both forms, sample cards...) asks for
+// the same six config-type lists. useSWR dedupes by key, so as long as every
+// caller uses this hook they share one in-flight request and one cache entry
+// per type instead of each mount firing its own fetch.
+async function fetchConfigType(url: string) {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}`)
+  }
+  const config = await response.json()
+  return config?.data
+}
+
+const swrOptions = {
+  revalidateOnFocus: false,
+  revalidateIfStale: false,
+  dedupingInterval: 3_600_000,
+} as const
+
+function withFallback<T>(data: T[] | undefined, fallback: T[]): T[] {
+  return data && data.length > 0 ? data : fallback
+}
+
 /**
  * Hook to get configuration types from database with fallback to defaults
  * Can be used as a drop-in replacement for direct imports from @/utils/types
  */
 export function useConfigTypes(): UseConfigTypesResult {
-  const [configs, setConfigs] = useState({
-    sampletypes: defaultSampleTypes,
-    traittypes: defaultTraitTypes,
-    equipmenttypes: defaultEquipmentTypes,
-    samplesubtypes: defaultSampleSubtypes,
-    silkcategories: defaultSilkCategories,
-    siprefixes: defaultSIprefixes
-  })
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const sampletypes = useSWR('/api/config/types?type=sampletypes', fetchConfigType, swrOptions)
+  const traittypes = useSWR('/api/config/types?type=traittypes', fetchConfigType, swrOptions)
+  const equipmenttypes = useSWR('/api/config/types?type=equipmenttypes', fetchConfigType, swrOptions)
+  const samplesubtypes = useSWR('/api/config/types?type=samplesubtypes', fetchConfigType, swrOptions)
+  const silkcategories = useSWR('/api/config/types?type=silkcategories', fetchConfigType, swrOptions)
+  const siprefixes = useSWR('/api/config/types?type=siprefixes', fetchConfigType, swrOptions)
 
-  const fetchConfigs = async () => {
-    setLoading(true)
-    setError(null)
-    
-    try {
-      const configTypes = ['sampletypes', 'traittypes', 'equipmenttypes', 'samplesubtypes', 'silkcategories', 'siprefixes']
-      const newConfigs = {
-        sampletypes: defaultSampleTypes,
-        traittypes: defaultTraitTypes,
-        equipmenttypes: defaultEquipmentTypes,
-        samplesubtypes: defaultSampleSubtypes,
-        silkcategories: defaultSilkCategories,
-        siprefixes: defaultSIprefixes
-      }
-
-      const results = await Promise.allSettled(
-        configTypes.map(async (configType) => {
-          const response = await fetch(`/api/config/types?type=${configType}`)
-          if (!response.ok) {
-            throw new Error(`Failed to fetch ${configType}`)
-          }
-          const config = await response.json()
-          return { configType, config }
-        })
-      )
-
-      results.forEach((result, index) => {
-        const configType = configTypes[index]
-        if (result.status === 'fulfilled') {
-          const { config } = result.value
-          if (config && config.data && config.data.length > 0) {
-            newConfigs[configType as keyof typeof newConfigs] = config.data
-          }
-        } else {
-          console.warn(`Using default ${configType}:`, result.reason)
-        }
-      })
-
-      setConfigs(newConfigs)
-    } catch (err) {
-      console.error('Error fetching configs:', err)
-      setError('Failed to fetch configuration')
-      // Keep default values on error
-    } finally {
-      setLoading(false)
-    }
+  const all = [sampletypes, traittypes, equipmenttypes, samplesubtypes, silkcategories, siprefixes]
+  const loading = all.some((r) => r.data === undefined && !r.error)
+  const error = all.some((r) => r.error) ? 'Failed to fetch configuration' : null
+  const refresh = () => {
+    all.forEach((r) => r.mutate())
   }
 
-  useEffect(() => {
-    fetchConfigs()
-  }, [])
-
   return {
-    ...configs,
+    sampletypes: withFallback(sampletypes.data, defaultSampleTypes),
+    traittypes: withFallback(traittypes.data, defaultTraitTypes),
+    equipmenttypes: withFallback(equipmenttypes.data, defaultEquipmentTypes),
+    samplesubtypes: withFallback(samplesubtypes.data, defaultSampleSubtypes),
+    silkcategories: withFallback(silkcategories.data, defaultSilkCategories),
+    siprefixes: withFallback(siprefixes.data, defaultSIprefixes),
     loading,
     error,
-    refresh: fetchConfigs
+    refresh,
   }
 }
 

--- a/src/utils/handlers/experimentHandlers.tsx
+++ b/src/utils/handlers/experimentHandlers.tsx
@@ -5,15 +5,20 @@ import { debounce } from "@/utils/debounce";
 
 
 export const handleDeleteExperiment = async (experimentId: any) => {
-  const res = await fetch(`${prepend_path}/api/experiments`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id: experimentId })
-  });
-  mutate(`${prepend_path}/api/experiments`);
-  if (!res.ok) {
+  try {
+    const res = await fetch(`${prepend_path}/api/experiments`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: experimentId })
+    });
+    if (!res.ok) throw new Error('Could not delete the experiment');
+  } catch (e) {
+    // Catches both a non-OK response and fetch() itself rejecting (offline,
+    // DNS/CORS) — either way the delete didn't happen.
     toast.error('Could not delete the experiment');
-    throw new Error('Could not delete the experiment');
+    throw e;
+  } finally {
+    mutate(`${prepend_path}/api/experiments`);
   }
 };
 

--- a/src/utils/handlers/experimentHandlers.tsx
+++ b/src/utils/handlers/experimentHandlers.tsx
@@ -5,13 +5,16 @@ import { debounce } from "@/utils/debounce";
 
 
 export const handleDeleteExperiment = async (experimentId: any) => {
-  // DELETE request to remove sample
-  await fetch(`${prepend_path}/api/experiments`, {
+  const res = await fetch(`${prepend_path}/api/experiments`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ id: experimentId })
   });
   mutate(`${prepend_path}/api/experiments`);
+  if (!res.ok) {
+    toast.error('Could not delete the experiment');
+    throw new Error('Could not delete the experiment');
+  }
 };
 
 export const handleBulkDeleteExperiments = async (experimentIds: string[]) => {

--- a/src/utils/handlers/sampleHandlers.js
+++ b/src/utils/handlers/sampleHandlers.js
@@ -8,12 +8,16 @@ export const handleEditSample = async (sample, setEditingSample) => {
 };
 
 export const handleDeleteSample = async (sampleId) => {
-    await fetch(`${prepend_path}/api/samples`, {
+    const res = await fetch(`${prepend_path}/api/samples`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: sampleId })
     });
     mutate(`${prepend_path}/api/samples`);
+    if (!res.ok) {
+        toast.error('Could not delete the sample');
+        throw new Error('Could not delete the sample');
+    }
 };
 
 export const handleBulkDeleteSamples = async (sampleIds) => {

--- a/src/utils/handlers/sampleHandlers.js
+++ b/src/utils/handlers/sampleHandlers.js
@@ -8,15 +8,20 @@ export const handleEditSample = async (sample, setEditingSample) => {
 };
 
 export const handleDeleteSample = async (sampleId) => {
-    const res = await fetch(`${prepend_path}/api/samples`, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: sampleId })
-    });
-    mutate(`${prepend_path}/api/samples`);
-    if (!res.ok) {
+    try {
+        const res = await fetch(`${prepend_path}/api/samples`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: sampleId })
+        });
+        if (!res.ok) throw new Error('Could not delete the sample');
+    } catch (e) {
+        // Catches both a non-OK response and fetch() itself rejecting
+        // (offline, DNS/CORS) — either way the delete didn't happen.
         toast.error('Could not delete the sample');
-        throw new Error('Could not delete the sample');
+        throw e;
+    } finally {
+        mutate(`${prepend_path}/api/samples`);
     }
 };
 

--- a/src/utils/handlers/traitHandlers.js
+++ b/src/utils/handlers/traitHandlers.js
@@ -8,12 +8,16 @@ export const handleEditTrait = async (trait, setEditingTrait) => {
 };
 
 export const handleDeleteTrait = async (traitId) => {
-    await fetch(`${prepend_path}/api/traits`, {
+    const res = await fetch(`${prepend_path}/api/traits`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: traitId })
     });
     mutate(`${prepend_path}/api/traits`);
+    if (!res.ok) {
+        toast.error('Could not delete the trait');
+        throw new Error('Could not delete the trait');
+    }
 };
 
 export const handleBulkDeleteTraits = async (traitIds) => {

--- a/src/utils/handlers/traitHandlers.js
+++ b/src/utils/handlers/traitHandlers.js
@@ -8,15 +8,20 @@ export const handleEditTrait = async (trait, setEditingTrait) => {
 };
 
 export const handleDeleteTrait = async (traitId) => {
-    const res = await fetch(`${prepend_path}/api/traits`, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: traitId })
-    });
-    mutate(`${prepend_path}/api/traits`);
-    if (!res.ok) {
+    try {
+        const res = await fetch(`${prepend_path}/api/traits`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: traitId })
+        });
+        if (!res.ok) throw new Error('Could not delete the trait');
+    } catch (e) {
+        // Catches both a non-OK response and fetch() itself rejecting
+        // (offline, DNS/CORS) — either way the delete didn't happen.
         toast.error('Could not delete the trait');
-        throw new Error('Could not delete the trait');
+        throw e;
+    } finally {
+        mutate(`${prepend_path}/api/traits`);
     }
 };
 


### PR DESCRIPTION
## What
### Table state (#191, #192)
- `DataTable` persists sorting, column visibility and page size to `localStorage`, keyed by pathname so different sample-type tables don't share a setting. Page index is deliberately not persisted.
- When a column filter shrinks the result set past the current page, the table now snaps back to page 0 instead of showing "No results." with rows sitting on an earlier page.

### useConfigTypes (#193)
- Rewritten on top of SWR (was plain `useState`/`useEffect`). The ~9 call sites (navbar, sample pages, both forms, sample cards) now share one request per config type instead of each mount firing its own 6.

### Nav (#194, #195)
- Mobile menu is generated from the same `usersProps`/`samplesProps`/`experimentsProps`/`traitsProps`/`settingsProps` data as the desktop dropdowns, so a lab's custom sample types and Settings now show up on mobile too.
- Database switch uses `router.push` and clears the SWR cache (`mutate(() => true, ...)`) instead of `window.location.href`, so it no longer does a full page reload.

### Sample form (#196)
- Location toasts show a readable address instead of `JSON.stringify(geodata)`.
- `getAndSetLocation` (the already-granted-permission path) was setting the location field to the raw address object instead of a formatted string; extracted the prompt-path's address formatting into a shared `formatAddress` helper and used it in both places.

### Delete handling (#197)
- `handleDeleteSample`/`handleDeleteTrait`/`handleDeleteExperiment` now check `res.ok` and toast+throw on failure, matching the existing bulk-delete handlers.
- The row action's delete button shows a spinner and disables while the request is in flight.

### Column labels (#198)
- Reusable column factories (`sortableFilterableColumn`, `toggleFieldColumn`, `sampleColumn`, `customColumn`, etc. — covers every config-driven custom field) now carry `meta: { label }`.
- The Columns dropdown reads `column.columnDef.meta?.label` first, falling back to the humanised accessor key.

## Behaviour changes
- Table sort/column-visibility/page-size preferences survive navigating away and back
- A filter that empties the current page no longer shows a false "No results."
- Custom sample types and Settings appear in the mobile nav
- Switching database no longer reloads the whole app
- Location lookup toasts are readable text, not raw JSON
- A failed single-item delete now shows an error toast instead of silently reappearing
- Column visibility menu shows a custom field's actual label instead of its raw key

## Checks
- `next build`: pass
- `tsc --noEmit`: pass
- `npx eslint` on changed files: pass
- Tests: full suite (379 tests) pass

## Merge
### Base
`develop`

### Closes
#191, #192, #193, #194, #195, #196, #197, #198