### PR TITLE
fix(frontend): UX gaps #191–#198 + admin settings access

### DIFF
--- a/src/__tests__/components/use-current-user.test.tsx
+++ b/src/__tests__/components/use-current-user.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { SWRConfig } from "swr"
+import { useCurrentUser } from "@/hooks/useCurrentUser"
+
+let session: unknown = { user: { name: "admin", sub: "demo|admin" } }
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: session, status: "authenticated" }),
+}))
+
+const originalFetch = global.fetch
+
+// Mirror the global SWRConfig fetcher: throw on a non-OK response.
+function mockFetch(handler: (url: string) => { status?: number; body: unknown }) {
+  global.fetch = jest.fn((url: string) => {
+    const { status = 200, body } = handler(String(url))
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    })
+  }) as unknown as typeof fetch
+}
+
+function Probe() {
+  const { isAdmin, userError } = useCurrentUser()
+  return (
+    <div>
+      <span data-testid="isAdmin">{String(isAdmin)}</span>
+      <span data-testid="error">{userError ? "error" : "ok"}</span>
+    </div>
+  )
+}
+
+const renderProbe = () =>
+  render(
+    <SWRConfig
+      value={{
+        dedupingInterval: 0,
+        provider: () => new Map(),
+        fetcher: async (url: string) => {
+          const res = await fetch(url)
+          if (!res.ok) {
+            const e = new Error("fetch failed") as Error & { status: number }
+            e.status = res.status
+            throw e
+          }
+          return res.json()
+        },
+      }}
+    >
+      <Probe />
+    </SWRConfig>,
+  )
+
+afterEach(() => {
+  global.fetch = originalFetch
+  jest.clearAllMocks()
+  session = { user: { name: "admin", sub: "demo|admin" } }
+})
+
+test("a signed-in admin reads back as admin", async () => {
+  mockFetch((url) =>
+    url.endsWith("/role")
+      ? { body: { role: "admin", isAdmin: true, capabilities: [] } }
+      : { body: { auth0id: "demo|admin", role: "admin" } },
+  )
+  renderProbe()
+  await waitFor(() => expect(screen.getByTestId("isAdmin")).toHaveTextContent("true"))
+})
+
+test("a 401 on the role route surfaces as an error, not a silent non-admin", async () => {
+  mockFetch(() => ({ status: 401, body: { error: "Unauthorized", code: "unauthorized" } }))
+  renderProbe()
+  await waitFor(() => expect(screen.getByTestId("error")).toHaveTextContent("error"))
+  expect(screen.getByTestId("isAdmin")).toHaveTextContent("false")
+})

--- a/src/app/(nest)/settings/admin/page.tsx
+++ b/src/app/(nest)/settings/admin/page.tsx
@@ -8,6 +8,7 @@ import { Trash } from "@phosphor-icons/react"
 import { useCurrentUser } from "@/hooks/useCurrentUser"
 import { useUserData } from "@/hooks/useUserData"
 import { prepend_path } from "@/lib/utils"
+import { swrFetcher } from "@/lib/swr-fetcher"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -28,8 +29,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-
-const fetcher = (url: string) => fetch(url).then((r) => r.json())
 
 interface Role {
   value: string
@@ -316,7 +315,7 @@ export default function AdminSettingsPage() {
     roles: Role[]
     permissions: Permission[]
     capabilities: Capability[]
-  }>(isAdmin ? `${prepend_path}/api/config/roles` : null, fetcher, {
+  }>(isAdmin ? `${prepend_path}/api/config/roles` : null, swrFetcher, {
     // The editors seed their draft from this data; a focus revalidation
     // mid-edit would otherwise discard unsaved changes.
     revalidateOnFocus: false,

--- a/src/app/providers/swr-provider.tsx
+++ b/src/app/providers/swr-provider.tsx
@@ -2,13 +2,7 @@
 'use client';
 
 import { SWRConfig } from 'swr';
-
-// Define type for cache value
-type State<Data = any, Error = any> = {
-  data?: Data;
-  error?: Error;
-  timestamp?: number;
-};
+import { swrFetcher } from '@/lib/swr-fetcher';
 
 const SWRProvider = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -36,16 +30,7 @@ const SWRProvider = ({ children }: { children: React.ReactNode }) => {
         },
 
         // Configure fetcher globally
-        fetcher: async (url: string) => {
-          const res = await fetch(url);
-          if (!res.ok) {
-            const error = new Error('An error occurred while fetching the data.');
-            // @ts-ignore
-            error.status = res.status;
-            throw error;
-          }
-          return res.json();
-        }
+        fetcher: swrFetcher,
       }}
     >
       {children}

--- a/src/components/config-setup.tsx
+++ b/src/components/config-setup.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { Check, CaretLeft } from "@phosphor-icons/react"
 
 import { prepend_path } from "@/lib/utils"
+import { swrFetcher } from "@/lib/swr-fetcher"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -26,8 +27,6 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json())
-
 interface Preset {
   value: string
   label: string
@@ -42,7 +41,7 @@ interface ConfigSetupProps {
 }
 
 function Wizard({ onComplete }: { onComplete: () => void }) {
-  const { data: presets } = useSWR<Preset[]>(`${prepend_path}/api/config/presets`, fetcher)
+  const { data: presets } = useSWR<Preset[]>(`${prepend_path}/api/config/presets`, swrFetcher)
   const [step, setStep] = useState(0)
   const [labName, setLabName] = useState("")
   const [labDescription, setLabDescription] = useState("")

--- a/src/hooks/useCurrentUser.js
+++ b/src/hooks/useCurrentUser.js
@@ -1,17 +1,17 @@
 // useCurrentUser.js
+// Uses the global SWRConfig fetcher (src/lib/swr-fetcher.ts), which throws on a
+// non-OK response. With a local `res.json()` fetcher a 401/403 from /api/user or
+// /api/user/role resolved with the error body as data, so a signed-in admin whose
+// request failed silently read back as a non-admin (no admin settings).
 import { useSession } from "next-auth/react";
 import useSWR from 'swr';
 
-const fetcher = url => fetch(url).then(res => res.json());
-
 export const useCurrentUser = () => {
     const { data: session, status } = useSession();
-    
+
     const { data: userData, error } = useSWR(
         session?.user ? '/api/user' : null,
-        fetcher,
         {
-            revalidateIfStale: false,
             revalidateOnFocus: false,
             dedupingInterval: 300000, // 5 minutes
         }
@@ -19,9 +19,7 @@ export const useCurrentUser = () => {
 
     const { data: roleData, error: roleError } = useSWR(
         session?.user ? '/api/user/role' : null,
-        fetcher,
         {
-            revalidateIfStale: false,
             revalidateOnFocus: false,
             dedupingInterval: 300000, // 5 minutes
         }

--- a/src/hooks/useDatabases.js
+++ b/src/hooks/useDatabases.js
@@ -1,11 +1,11 @@
 // useDatabases.js
+// Uses the global SWRConfig fetcher (src/lib/swr-fetcher.ts), which throws on a
+// non-OK response so `databasesError` reflects a failed request instead of
+// resolving with the error body as if it were data.
 import useSWR from 'swr';
 
-const fetcher = url => fetch(url).then(res => res.json());
-
 export const useDatabases = () => {
-    const { data, error, mutate } = useSWR('/api/databases', fetcher, {
-        revalidateIfStale: false,
+    const { data, error, mutate } = useSWR('/api/databases', {
         revalidateOnFocus: false,
         dedupingInterval: 300000, // 5 minutes
     });

--- a/src/hooks/usePreloadData.js
+++ b/src/hooks/usePreloadData.js
@@ -2,28 +2,20 @@
 import { useCallback } from 'react';
 import { preload } from 'swr';
 import { prepend_path } from '@/lib/utils';
-
-// Global fetcher function matching our SWR config
-const fetcher = async (url) => {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
-  }
-  return res.json();
-};
+import { swrFetcher } from '@/lib/swr-fetcher';
 
 // Preload specific data types
 export const usePreloadData = () => {
   const preloadSamples = useCallback(() => {
-    preload(`${prepend_path}/api/samples`, fetcher);
+    preload(`${prepend_path}/api/samples`, swrFetcher);
   }, []);
 
   const preloadTraits = useCallback(() => {
-    preload(`${prepend_path}/api/traits`, fetcher);
+    preload(`${prepend_path}/api/traits`, swrFetcher);
   }, []);
 
   const preloadExperiments = useCallback(() => {
-    preload(`${prepend_path}/api/experiments`, fetcher);
+    preload(`${prepend_path}/api/experiments`, swrFetcher);
   }, []);
 
   // Preload all data types

--- a/src/lib/swr-fetcher.ts
+++ b/src/lib/swr-fetcher.ts
@@ -1,0 +1,27 @@
+/**
+ * The one SWR fetcher for the app. It throws on a non-OK response so `error`
+ * from `useSWR` reflects a failed request; a bare `fetch(url).then(r => r.json())`
+ * instead resolves with the error body as if it were data, which silently turns
+ * a 401/403/500 into "the field is just missing" at the call site.
+ *
+ * `SWRConfig` in `swr-provider.tsx` installs this as the default, so a hook that
+ * passes no fetcher already gets it. Import it directly only where you can't rely
+ * on that context: an explicit fetcher argument, or `preload()`.
+ */
+
+export interface FetchError extends Error {
+  status?: number;
+  /** The parsed error body, when the response had one. */
+  info?: unknown;
+}
+
+export const swrFetcher = async <T = unknown>(url: string): Promise<T> => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const error: FetchError = new Error("An error occurred while fetching the data.");
+    error.status = res.status;
+    error.info = await res.json().catch(() => undefined);
+    throw error;
+  }
+  return res.json() as Promise<T>;
+};


### PR DESCRIPTION
## What

### Frontend UX fixes (#191–#198)
- `DataTable` persists sorting / column visibility / page size to `localStorage` (per pathname, plus a `tableId` for routes with more than one table), and snaps to page 0 only when a filter empties the current page
- `useConfigTypes` is SWR-backed so its 6 config-type requests are shared across every mount instead of refetched per component
- Mobile nav is generated from the same section data as the desktop menu, so custom sample types and Settings appear on both
- Database switch uses `router.push` + SWR cache clear instead of a full page reload; mobile menu closes explicitly on switch
- Sample-form location toasts show a readable address instead of raw JSON, on both the prompt and granted-permission paths
- Single-item delete (sample / trait / experiment) checks `res.ok` **and** catches a rejected `fetch` (offline/DNS/CORS), toasts on failure, and shows a pending state on the button; direct callers updated to handle the now-throwing handlers
- Column visibility menu reads a column's `meta.label` where set, humanised key otherwise

### Admin settings access
`useCurrentUser` had its own fetcher that never checked `res.ok`, so a 401/403/500 from `/api/user` or `/api/user/role` resolved with the error body *as data*. `isAdmin` then computed from a body with no `isAdmin`/`role` field and read `false` — a signed-in admin lost the admin settings card in `/settings` with no error shown, and `revalidateIfStale: false` kept it stuck until a hard reload.

- Extracted the canonical fetcher to `src/lib/swr-fetcher.ts` (throws on non-OK, carries `.status` / `.info`); `SWRConfig` installs it as the default
- Pointed the four call sites that still inlined a `res.ok`-less fetcher at it: `useCurrentUser`, `useDatabases`, `settings/admin`, `config-setup`
- `usePreloadData` imports it instead of hand-copying
- Regression tests for `useCurrentUser`: admin path, and a 401 surfacing as an error instead of a silent non-admin

## Behaviour changes
- Table view preferences survive navigation and reload
- A failed delete now always surfaces a toast instead of sometimes failing silently (or navigating away anyway)
- An admin whose role request fails transiently recovers on the next navigation instead of being stuck as a non-admin

## Checks
- `next build --webpack`: pass
- `tsc --noEmit`: pass
- Tests: `jest` full suite — 60 suites, 381 tests pass (incl. 2 new `useCurrentUser` tests)

## Merge
### Base
`develop`.

### Closes
#191, #192, #193, #194, #195, #196, #197, #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)